### PR TITLE
Add Travis CI support for integration tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+language: node_js
+node_js:
+  - "node"
+  - "6"
+  - "5"

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,11 @@ node_js:
   - "node"
   - "6"
   - "5"
+addons:
+  apt:
+    sources:
+    - ubuntu-toolchain-r-test
+    packages:
+    - g++-4.8
+env:
+  CXX=g++-4.8

--- a/README.md
+++ b/README.md
@@ -56,6 +56,12 @@ is easily made by answering the following question.
 
 > Is this a scheduled downtime issue?
 
+## Continuous Integration
+
+This project is tested with Travis-CI. The current versions of node that are
+being tested are the `latest`, `6.x`, and `5.x`. Please see the `.travis.yml` at
+the root of this repository for more info.
+
 ## Dependencies
 
 This project has dependencies outlined in [the `package.json` file](package.json)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Coming Attractions
 
+[![Build Status](https://travis-ci.org/18F/coming-attractions.svg?branch=master)](https://travis-ci.org/18F/coming-attractions)
+
 For those moments when you need to redirect traffic to a static site for any
 number of reasons that share the same thing in common, _alerting your users in a
 quick and easy way during an incident response_. The incident could be scheduled

--- a/source/cf/install-cf-plugins.sh
+++ b/source/cf/install-cf-plugins.sh
@@ -2,6 +2,12 @@
 
 set -e
 
+if [ $TRAVIS ]
+then
+  echo "Skipping installation of scaleover"
+  exit 1
+fi
+
 if [ $npm_package_config_install_scaleover == false ]; then
   echo "Skipping installation of scaleover"
   exit 0

--- a/source/cf/install-cf-plugins.sh
+++ b/source/cf/install-cf-plugins.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-if [ $TRAVIS ]
+if [ -n $TRAVIS ]
 then
   echo "Skipping installation of scaleover"
   exit 1

--- a/source/cf/install-cf-plugins.sh
+++ b/source/cf/install-cf-plugins.sh
@@ -5,7 +5,7 @@ set -e
 if [ -n $TRAVIS ]
 then
   echo "Skipping installation of scaleover"
-  exit 1
+  exit 0
 fi
 
 if [ $npm_package_config_install_scaleover == false ]; then


### PR DESCRIPTION
Once this lands on `master`, the badge in the `README.md` file will work, but for now this should give integration tests for any pushes or PRs with a `.travis.yml` file. 👍 

cc: @glbrtmrgn 